### PR TITLE
build: Dockerfile cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@
 FROM myoung34/github-runner:ubuntu-jammy
 
 # Install CUDA and OpenCL
-RUN apt update && \
-    apt install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     nvidia-cuda-toolkit \
     clinfo \
-    ocl-icd-dev
+    ocl-icd-dev \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility


### PR DESCRIPTION
- Optimize Dockerfile by using `apt-get` and minimizing final image size
- Enhance installation process with `--no-install-recommends` flag
- Clean up unneeded files after installation to further decrease image size