### PR TITLE
Install gcc-10 for GPU test workaround

### DIFF
--- a/gpu-runner/Dockerfile
+++ b/gpu-runner/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     clinfo \
     ocl-icd-dev \
     ocl-icd-opencl-dev \
+    gcc-10 g++-10 \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Used for `lurk-rs` only via https://github.com/lurk-lab/lurk-rs/pull/458