### PR TITLE
Fix nvidia-smi NVML error in GPU CI

### DIFF
--- a/gpu-runner/gh-actions-runner-compose.yml
+++ b/gpu-runner/gh-actions-runner-compose.yml
@@ -12,6 +12,7 @@ services:
       LABELS: linux,x64,gpu
       DISABLE_AUTO_UPDATE: 1
       EPHEMERAL: 1
+      LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libnvidia-ml.so
     deploy:
       resources:
         reservations:
@@ -19,6 +20,10 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu, compute, utility]
+    devices:
+      - "/dev/nvidiactl"
+      - "/dev/nvidia-uvm"
+      - "/dev/nvidia0"
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
       - '/var/tmp/runner:/var/tmp/runner'

--- a/gpu-runner/gh-actions-runner.service
+++ b/gpu-runner/gh-actions-runner.service
@@ -18,6 +18,8 @@ Environment="COMPOSE_FILE=/etc/gh-actions-runner-compose.yml" \
 # Docker pull shouldn't take longer than 5 minutes
 TimeoutStartSec=5min
 Restart=always
+# Test that the Docker service has access to the GPU drivers
+ExecStartPre=/usr/bin/docker run --rm --runtime=nvidia --gpus all nvidia/cuda:11.5.2-base-ubuntu20.04 nvidia-smi
 ExecStartPre=-/usr/bin/docker compose \
                       -f $COMPOSE_FILE \
                       --env-file $ENV_FILE \


### PR DESCRIPTION
Fixes `Failed to initialize NVML: Unknown Error`, found in e.g. https://github.com/lurk-lab/lurk-rs/actions/runs/5622777146/job/15236057859. The solution was found thanks to @huitseeker in https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nvidia_smi#limitations

Also requires adding a udev rule to create driver symlinks as per https://github.com/NVIDIA/nvidia-docker/issues/1671#issuecomment-1419720602