### PR TITLE
Assign unique workdirs for docker-compose runners

### DIFF
--- a/gpu-runner/Dockerfile
+++ b/gpu-runner/Dockerfile
@@ -23,3 +23,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:~/.cargo/bin"
 
 RUN rustc --version
+
+COPY entrypoint-wrapper.sh /
+ENTRYPOINT ["/entrypoint-wrapper.sh"]
+CMD ["/actions-runner/bin/runsvc.sh"]
+VOLUME /var/tmp/runner

--- a/gpu-runner/entrypoint-wrapper.sh
+++ b/gpu-runner/entrypoint-wrapper.sh
@@ -1,0 +1,9 @@
+# For peace of mind that the workdir exists
+mkdir -p /var/tmp/runner/_work
+# Generate a unique, persistent id for each runner directory
+head /dev/urandom | tr -dc a-f0-9 | head -c 13 > /var/tmp/runner/_work/runner_id.txt
+_RUNNER_ID="$(cat /var/tmp/runner/_work/runner_id.txt)"
+RUNNER_NAME="${RUNNER_NAME}-${_RUNNER_ID}"
+RUNNER_WORKDIR="${RUNNER_WORKDIR}/${_RUNNER_ID}"
+
+exec /entrypoint.sh $@

--- a/gpu-runner/gh-actions-runner-compose.yml
+++ b/gpu-runner/gh-actions-runner-compose.yml
@@ -8,7 +8,7 @@ services:
       REPO_URL: ${REPO_URL}
       ACCESS_TOKEN: ${ACCESS_TOKEN}
       RUNNER_SCOPE: repo
-      RUNNER_WORKDIR: /var/tmp/runner/work
+      RUNNER_WORKDIR: /var/tmp/runner/_work
       LABELS: linux,x64,gpu
       DISABLE_AUTO_UPDATE: 1
       EPHEMERAL: 1

--- a/gpu-runner/gh-actions-runner.service
+++ b/gpu-runner/gh-actions-runner.service
@@ -28,6 +28,7 @@ ExecStartPre=-/usr/bin/docker compose \
                         -f $COMPOSE_FILE \
                         --env-file $ENV_FILE \
                         rm %N
+#ExecStartPre=-rm -r /var/tmp/runner
 ExecStart=/usr/bin/docker compose \
                     -f $COMPOSE_FILE \
                     --env-file $ENV_FILE \


### PR DESCRIPTION
This approach is based on https://github.com/ixc/github-actions-runner-docker/tree/main. The scaled directories are persistent as it was non-trivial to figure out how to remove them and it doesn't cause any issues.

Closes #7 (hopefully) as each scaled runner will be fully isolated, so simultaneous checkouts won't conflict.

Related issue: https://github.com/myoung34/docker-github-actions-runner/issues/72