### PR TITLE
gpu-runner: Remove dependency on `gcc-10`/`g++-10`

### DIFF
--- a/gpu-runner/Dockerfile
+++ b/gpu-runner/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && \
     clinfo \
     ocl-icd-dev \
     ocl-icd-opencl-dev \
-    gcc-10 g++-10 \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gpu-runner/Dockerfile
+++ b/gpu-runner/Dockerfile
@@ -1,5 +1,5 @@
 # Use pre-configured GitHub runner action
-FROM lurklab/gh-actions-runner-cuda:dev
+FROM lurklab/gh-actions-runner-cuda:latest
 
 # Install CUDA and OpenCL
 RUN apt-get update && \


### PR DESCRIPTION
#12 fixed the compile error documented in https://github.com/lurk-lab/lurk-rs/issues/597, so these dependencies are no longer needed in the `Dockerfile`.