### PR TITLE
Add `nullfs` setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ The instructions are the same as above, with the following modifications:
     ```
     Then reboot and check `nvidia-smi` is working
 - Individual runner
-  - Run `./gpu_setup.sh` instead of `setup.sh`, and then `./install.sh` as usual
-  - Note: Tested on Paperspace, behavior may vary with other providers
+  - Run `./gpu_setup.sh` instead of `setup.sh`
+    - Note: Tested on Paperspace, GCP, and AWS. Behavior may vary with other providers
+  - Optionally run `./nullfs.sh` for `lurk-rs` runners to disable public parameter caching
+  - Then run `./install.sh`
+  - Don't forget to add the cleanup cron jobs as with the test runner
 - Vultr Nvidia runner;
   - Don't run `apt update`/`apt upgrade`, as a new kernel version will break the GPU drivers
   - Run `./vultr_setup.sh` instead of `setup.sh`, and then `./install.sh` as usual

--- a/scripts/nullfs.sh
+++ b/scripts/nullfs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+## Script to install and configure nullfs to force-deactivate public param caching
+
+# Install nullfs
+git clone https://github.com/abbbi/nullfsvfs.git
+cd nullfsvfs
+sudo apt-get install debhelper dkms
+sudo dpkg-buildpackage -r
+# Update below version as needed
+sudo dpkg -i ../nullfsvfs_0.17_amd64.deb
+
+# Set up nullfs
+sudo modprobe nullfs
+echo nullfs | sudo tee /etc/modules-load.d/nullfs.conf
+NFS_USERNAME=$(whoami)
+NFS_UID=$(id -u $NFS_USERNAME)
+NFS_GID=$(id -g $NFS_USERNAME)
+sudo mkdir -p /var/tmp/runner/lurk
+echo "none /var/tmp/runner/lurk nullfs default,uid=$NFS_UID,gid=$NFS_GID 0 0" | sudo tee -a /etc/fstab
+
+# Mount nullfs to the Docker runner
+echo "      - '/var/tmp/runner/lurk:/root/.lurk'" >> gh-actions-runner-compose.yml
+
+# Mount nullfs to the file system
+sudo mount -a
+# Check it worked
+mount
+

--- a/scripts/server_files.sh
+++ b/scripts/server_files.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# E.g. ../test-runner/gh-actions-runner*
-scp /path/to/runner/gh-actions-runner* <user>@<ip_addr>:/path/to/home
+# Run this script from its local `scripts` directory
 
-# For GPU setup, replace setup.sh with gpu_setup.sh below
-scp setup.sh install.sh remove.sh runner_cleanup.sh docker_cleanup.sh <user>@<ip_addr>:/path/to/home
+# Edit this path for non-GPU runner
+scp ../gpu-runner/gh-actions-runner* <user>@<ip_addr>:/path/to/home
+
+# For non-GPU runner, replace gpu_setup.sh with setup.sh below
+scp gpu_setup.sh nullfs.sh install.sh remove.sh runner_cleanup.sh docker_cleanup.sh <user>@<ip_addr>:/path/to/home


### PR DESCRIPTION
This enables `lurk-rs` runners to quickly implement https://github.com/abbbi/nullfsvfs in order to disable public parameter caching. Since it's more specific to Lurk than prior work, it's possible that it belongs somewhere else, but this is the easiest place to integrate with our current setup.