### PR TITLE
GPU runner updates

### DIFF
--- a/gpu-runner/gh-actions-runner-compose.yml
+++ b/gpu-runner/gh-actions-runner-compose.yml
@@ -18,7 +18,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: 1
+              count: all
               capabilities: [gpu, compute, utility]
     devices:
       - "/dev/nvidiactl"

--- a/gpu-runner/gh-actions-runner.service
+++ b/gpu-runner/gh-actions-runner.service
@@ -28,7 +28,7 @@ ExecStartPre=-/usr/bin/docker compose \
                         -f $COMPOSE_FILE \
                         --env-file $ENV_FILE \
                         rm %N
-#ExecStartPre=-rm -r /var/tmp/runner
+ExecStartPre=-rm -r /var/tmp/runner/*
 ExecStart=/usr/bin/docker compose \
                     -f $COMPOSE_FILE \
                     --env-file $ENV_FILE \

--- a/scripts/gpu_drivers.sh
+++ b/scripts/gpu_drivers.sh
@@ -3,6 +3,7 @@
 sudo apt-get update && sudo apt-get upgrade -y
 sudo apt-get install ubuntu-drivers-common -y
 sudo ubuntu-drivers devices
-sudo ubuntu-drivers autoinstall
+# Edit with the desired driver number (e.g. 535)
+sudo ubuntu-drivers install <driver>
 
 # Then reboot and run `nvidia-smi`

--- a/scripts/gpu_drivers.sh
+++ b/scripts/gpu_drivers.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install ubuntu-drivers-common -y
+sudo ubuntu-drivers devices
+sudo ubuntu-drivers autoinstall
+
+# Then reboot and run `nvidia-smi`

--- a/scripts/nullfs.sh
+++ b/scripts/nullfs.sh
@@ -5,7 +5,7 @@
 # Install nullfs
 git clone https://github.com/abbbi/nullfsvfs.git
 cd nullfsvfs
-sudo apt-get install debhelper dkms
+sudo apt-get install debhelper dkms -y
 sudo dpkg-buildpackage -r
 # Update below version as needed
 sudo dpkg -i ../nullfsvfs_0.17_amd64.deb

--- a/scripts/nullfs.sh
+++ b/scripts/nullfs.sh
@@ -20,7 +20,7 @@ sudo mkdir -p /var/tmp/runner/lurk
 echo "none /var/tmp/runner/lurk nullfs default,uid=$NULLFS_UID,gid=$NULLFS_GID 0 0" | sudo tee -a /etc/fstab
 
 # Mount nullfs to the Docker runner
-echo "      - '/var/tmp/runner/lurk:/root/.lurk'" >> gh-actions-runner-compose.yml
+echo "      - '/var/tmp/runner/lurk:/root/.lurk'" >> ~/gh-actions-runner-compose.yml
 
 # Mount nullfs to the file system
 sudo mount -a

--- a/scripts/server_files.sh
+++ b/scripts/server_files.sh
@@ -5,5 +5,5 @@
 # Edit this path for non-GPU runner
 scp ../gpu-runner/gh-actions-runner* <user>@<ip_addr>:/path/to/home
 
-# For non-GPU runner, replace gpu_setup.sh with setup.sh below
-scp gpu_setup.sh nullfs.sh install.sh remove.sh runner_cleanup.sh docker_cleanup.sh <user>@<ip_addr>:/path/to/home
+# For non-GPU runner, replace gpu_setup.sh and gpu_drivers.sh with setup.sh below
+scp gpu_setup.sh gpu_drivers.sh nullfs.sh install.sh remove.sh runner_cleanup.sh docker_cleanup.sh <user>@<ip_addr>:/path/to/home


### PR DESCRIPTION
- Cleans up prior workdirs and `nullfs` public params if applicable on each `systemd` service startup. Since the `nullfs` files are empty they could be ignored, but I figure it can't hurt to clean them up too.
- Adds a GPU driver install script for convenience.
- Uses GPU `count: all` in Docker Compose to enable multi-GPU containers