### PR TITLE
Remove cached Rust install

### DIFF
--- a/bench-runner/Dockerfile
+++ b/bench-runner/Dockerfile
@@ -8,14 +8,6 @@ RUN apt update \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-ENV PATH="${PATH}:/root/.cargo/bin"
-
-RUN rustc --version
-RUN cargo install critcmp
-
 COPY entrypoint-wrapper.sh /
 ENTRYPOINT ["/entrypoint-wrapper.sh"]
 CMD ["/actions-runner/bin/runsvc.sh"]

--- a/gpu-runner/Dockerfile
+++ b/gpu-runner/Dockerfile
@@ -19,13 +19,6 @@ RUN nvcc --version
 RUN mkdir -p /etc/OpenCL/vendors && \
     echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-ENV PATH="${PATH}:/root/.cargo/bin"
-
-RUN rustc --version
-
 COPY entrypoint-wrapper.sh /
 ENTRYPOINT ["/entrypoint-wrapper.sh"]
 CMD ["/actions-runner/bin/runsvc.sh"]

--- a/test-runner/Dockerfile
+++ b/test-runner/Dockerfile
@@ -8,13 +8,6 @@ RUN apt update \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-ENV PATH="${PATH}:/root/.cargo/bin"
-
-RUN rustc --version
-
 COPY entrypoint-wrapper.sh /
 ENTRYPOINT ["/entrypoint-wrapper.sh"]
 CMD ["/actions-runner/bin/runsvc.sh"]


### PR DESCRIPTION
Fixes an issue where a system-wide Rust install caused errors when updating across Docker layers with the `dtolnay/rust-toolchain` action: https://github.com/rust-lang/rustup/issues/1239#issuecomment-1212541656

This means we'll have to download Rust on every job, unless we devise some other caching mechanism, but it seems to only take ~15s so likely not worth it.

Successful run showing the correct `PATH` after `dtolnay/rust-toolchain`: https://github.com/lurk-lab/ci-lab/actions/runs/7391239436/job/20107650902 