### PR TITLE
Add update & reboot script

### DIFF
--- a/scripts/update-reboot.sh
+++ b/scripts/update-reboot.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Run this script regularly (e.g. monthly) to update security and prevent driver issues
+# Example cron job:
+# 0 0 1 * * ./update-reboot.sh
+
+sudo apt update && sudo apt upgrade
+sudo reboot


### PR DESCRIPTION
Requesting review about whether this is a good idea as opposed to scheduling manual upgrades.
- We have an existing `docker_cleanup.sh` script that may run at the same time, could the system reboot before finishing it?