### PR TITLE
Pin GPU driver and kernel

### DIFF
--- a/gpu-runner/gh-actions-runner.service
+++ b/gpu-runner/gh-actions-runner.service
@@ -28,7 +28,7 @@ ExecStartPre=-/usr/bin/docker compose \
                         -f $COMPOSE_FILE \
                         --env-file $ENV_FILE \
                         rm %N
-ExecStartPre=-rm -r /var/tmp/runner/*
+ExecStartPre=-rm -r /var/tmp/runner/_work
 ExecStart=/usr/bin/docker compose \
                     -f $COMPOSE_FILE \
                     --env-file $ENV_FILE \

--- a/scripts/gpu_drivers.sh
+++ b/scripts/gpu_drivers.sh
@@ -7,13 +7,15 @@ printf "APT::Install-Suggests "0";\nAPT::Install-Recommends "0";" >> /etc/apt/ap
 
 sudo apt-get update && sudo apt-get upgrade -y
 # Pin kernel version to prevent driver/kernel mismatches
-sudo apt-mark hold linux-generic linux-image-generic linux-headers-generic
+sudo apt-mark hold linux-generic
 
-sudo apt-get install ubuntu-drivers-common -y
-sudo ubuntu-drivers devices
-# Edit with the desired driver number based on `ubuntu-drivers devices`
-sudo ubuntu-drivers install 535
+# `alsa-utils` is needed to fix an `aplay` error when running `ubuntu-drivers devices`
+sudo apt-get install ubuntu-drivers-common alsa-utils -y
+# Edit with the desired driver version based on `ubuntu-drivers devices`
+NVIDIA_DRIVER_VERSION=$(sudo ubuntu-drivers devices | grep "recommended" | awk -F'-' '{ print $3 }')
+
+sudo ubuntu-drivers install $NVIDIA_DRIVER_VERSION
 # Pin driver version to prevent driver/kernel mismatches
-sudo apt-mark hold nvidia-driver-535
+sudo apt-mark hold nvidia-driver-$NVIDIA_DRIVER_VERSION
 
 # Then reboot and run `nvidia-smi`

--- a/scripts/gpu_drivers.sh
+++ b/scripts/gpu_drivers.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
+# Disable popups to restart services after `apt-get upgrade` by restarting them automatically
+sudo sed -i "s/\#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
+# Don't install suggested or recommended packages with `apt`
+printf "APT::Install-Suggests "0";\nAPT::Install-Recommends "0";" >> /etc/apt/apt.conf.d/99Recommended
+
 sudo apt-get update && sudo apt-get upgrade -y
+# Pin kernel version to prevent driver/kernel mismatches
+sudo apt-mark hold linux-generic linux-image-generic linux-headers-generic
+
 sudo apt-get install ubuntu-drivers-common -y
 sudo ubuntu-drivers devices
-# Edit with the desired driver number (e.g. 535)
-sudo ubuntu-drivers install <driver>
+# Edit with the desired driver number based on `ubuntu-drivers devices`
+sudo ubuntu-drivers install 535
+# Pin driver version to prevent driver/kernel mismatches
+sudo apt-mark hold nvidia-driver-535
 
 # Then reboot and run `nvidia-smi`


### PR DESCRIPTION
- Pins the GPU driver and kernel version based on the discussion in #26
- Prevents installation of suggested/recommended `apt` packages
- Removes popups to restart services after `apt-get upgrade` in favor of restarting them automatically
- Removes prior runner workdirs (each contained in `/var/tmp/runner/_work/<UID>-<DATE>`)on each `systemd` run. Previous behavior also attempted to delete the mounted `nullfs` directory, which failed with `rm: cannot remove '/var/tmp/runner/lurk': Device or resource busy`.

> [!NOTE]
> The `unattended-upgrades` service appears to be preinstalled on GCP runners, but if there's a way to programmatically check it's working correctly that would be a good next step.